### PR TITLE
Fix: Codecov Actions and Global Upload Token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.QUANESTIMATION_TOKEN }}
-        slug: LiuJPhys/QuanEstimation
+        slug: QuanEstimation/QuanEstimation


### PR DESCRIPTION
I noticed that the Codecov data hasn’t been updating correctly. This PR should fix this; however, [the  `QUANESTIMATION_TOKEN`](https://github.com/organizations/QuanEstimation/settings/secrets/actions) needs to be set up properly. 

Admin access on the Codecov site has been transferred, @LiuJPhys could you please set the `QUANESTIMATION_TOKEN` as the Global Upload Token [here](https://app.codecov.io/account/gh/QuanEstimation/org-upload-token)?
