### PR TITLE
Enhancement: Speed Up Test Action by Prebuilding Julia Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: julia-actions/setup-julia@v2
       with:
         version: '1'
-    - run: julia -v
+    - run: julia -e 'using Pkg;Pkg.add(name="QuanEstimation",version="0.1.6");using QuanEstimation'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
### Overview
This PR reduces the CI test runtime from ~90 minutes to ~13 minutes by prebuilding Julia packages that were previously compiled during Python–Julia interop. @LiuJPhys 

### Changes
- Adds a prebuild step for Julia packages in the CI setup
- Speeds up test workflow with no impact on test logic or outputs